### PR TITLE
ci: test jazzy + lyrical dual-distro build [DO NOT MERGE]

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -4,13 +4,14 @@ on:
     push:
     pull_request:
 
-env:
-    ROS_WS: ${{ github.workspace }}/ros2_ws/
-    ROS_SRC: ${{ github.workspace }}/ros2_ws/src
-
 jobs:
-  ros-build:
-    uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/workflows/ubuntu-build.yml@main
-    # with:
-    #   # QRB ROS dependency
-    #   dependencies: "qualcomm-qrb-ros/qrb_ros_transport qualcomm-qrb-ros/lib_mem_dmabuf"
+  ros-build-jazzy:
+    uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/workflows/ubuntu-build.yml@test/lyrical-ci-preview
+    secrets: inherit
+    # ros-distro defaults to jazzy, no explicit with needed
+
+  ros-build-lyrical:
+    uses: qualcomm-qrb-ros/qrb_ros_gh_actions/.github/workflows/ubuntu-build.yml@test/lyrical-ci-preview
+    secrets: inherit
+    with:
+      ros-distro: lyrical


### PR DESCRIPTION
## Purpose

Test PR to validate the dual-distro CI changes in [qrb_ros_gh_actions#ci/lyrical-support](https://github.com/qualcomm-qrb-ros/qrb_ros_gh_actions/tree/ci/lyrical-support) before merging.

## What's being tested

- `ros-build-jazzy`: calls `ubuntu-build.yml@ci/lyrical-support` without `ros-distro` — validates backward compatibility (ubuntu-24.04-arm + QCOM PPA)
- `ros-build-lyrical`: calls with `ros-distro: lyrical` — validates new lyrical path (ubuntu-26.04-arm, no PPA)
- `secrets: inherit` forwarding for S3 upload

## Expected results

| Job | Runner | Container | PPA | Expected |
|-----|--------|-----------|-----|----------|
| ros-build-jazzy | ubuntu-24.04-arm | ros:jazzy | ✅ added | green |
| ros-build-lyrical | ubuntu-26.04-arm | ros:lyrical | ⛔ skipped | green |

## After test

Once both jobs pass, this PR will be closed. The final production PR will point to `@main` after qrb_ros_gh_actions is merged.

> **DO NOT MERGE** — test only