### PR TITLE
release: merge release/2.0.1 back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-07-09
+
+### Added
+- `qrb_ros_tensor_list_msgs`: Added `int32` (data_type `8`) as a supported QNN data type.
+
+### Fixed
+- Synced version numbers between `package.xml` and `CMakeLists.txt` for `qrb_ros_robot_base_msgs` and `qrb_ros_slam_msgs`.
+- Replaced `pull_request_target` with `pull_request` in CI workflows (security requirement).
+
+### Changed
+- Updated `Tensor.msg` documentation in README to include all data types and DMA-BUF fields.
+- Removed RB3 Gen2 hardware references from README.
+- Delegated preflight checks to reusable workflow in `qrb_ros_gh_actions`.
+
+## [2.0.0] - 2026-04-23
+
+### Added
+- `qrb_ros_tensor_list_msgs`: Added DMA-BUF transport support to `Tensor.msg`:
+  - New fields: `dmabuf_fd`, `dmabuf_size`, `dmabuf_offset`, `dmabuf_ptr` for zero-copy DMA-BUF based tensor data transfer.
+  - New data types: `uint16` (4), `float16` (5), `uint32` (6), `uint64` (7).
+- Added GitHub Pull Request template (`.github/PULL_REQUEST_TEMPLATE.md`).
+
+### Breaking Changes
+- `qrb_ros_tensor_list_msgs/msg/Tensor`: Adding new fields changes the ROS 2 message type hash, breaking wire compatibility with nodes built against `1.0.0`.
+
 ## [1.0.0] - 2025-11-28
 ### Added
 - CI pipeline for testing and building the packages.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ string name
 # 1: "int8"
 # 2: "float32"
 # 3: "float64"
+# 4: "uint16"
+# 5: "float16"
+# 6: "uint32"
+# 7: "uint64"
+# 8: "int32"
 int32 data_type
 
 # shape of tensor
@@ -126,6 +131,18 @@ uint32[] shape
 
 # data buffer
 uint8[] data
+
+# DMA-BUF file descriptor that contains tensor bytes. -1 means invalid / not used.
+int32 dmabuf_fd
+
+# DMA-BUF size in bytes.
+uint32 dmabuf_size
+
+# Optional byte offset within the DMA-BUF for this tensor.
+uint64 dmabuf_offset
+
+# pointer to DAM-BUF
+uint64 dmabuf_ptr
 ```
 
 ---

--- a/qrb_ros_robot_base_msgs/package.xml
+++ b/qrb_ros_robot_base_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qrb_ros_robot_base_msgs</name>
-  <version>1.0.0</version>
+  <version>1.2.3</version>
   <description>QRB ROS robot base msgs</description>
   <maintainer email="chenghen@qti.qualcomm.com">Chengheng Tan</maintainer>
   <maintainer email="quic_penwang@quicinc.com">Peng Wang</maintainer>

--- a/qrb_ros_slam_msgs/CMakeLists.txt
+++ b/qrb_ros_slam_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.8)
-project(qrb_ros_slam_msgs VERSION 0.1.0)
+project(qrb_ros_slam_msgs VERSION 1.2.3)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/qrb_ros_tensor_list_msgs/package.xml
+++ b/qrb_ros_tensor_list_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>qrb_ros_tensor_list_msgs</name>
-  <version>1.0.0</version>
+  <version>2.0.1</version>
   <description>Msgs for model inference</description>
   <maintainer email="quic_nasong@quicinc.com">Na Song</maintainer>
   <license>BSD-3-Clause-Clear</license>


### PR DESCRIPTION
Merge release/2.0.1 back to main after the 2.0.1 release.

  This also catches up the `qrb_ros_tensor_list_msgs` package version that was
  missed when release/2.0.0 was not merged back in its time.

  ### Changes included
  - `qrb_ros_tensor_list_msgs/package.xml`: 1.0.0 → 2.0.1
  - `qrb_ros_robot_base_msgs/package.xml`: synced to 1.2.3 (matches CMakeLists.txt)
  - `qrb_ros_slam_msgs/CMakeLists.txt`: synced to 1.2.3 (matches package.xml)
  - `README.md`: updated Tensor.msg documentation (data types + DMA-BUF fields)
  - `CHANGELOG.md`: added 2.0.0 and 2.0.1 entries